### PR TITLE
Avoid starting mailhog and adminer during testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,23 +8,23 @@ on:
 
 jobs:
   test:
-
     name: test
     runs-on: ubuntu-latest
-          
+
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v2
 
-    - name: Run application
-      run: docker-compose up -d
-    
-    - name: Test Resources
-      run: docker-compose run --rm manage test resources
+      - name: Run application
+        run: docker-compose up -d web
 
-    - name: Test Users
-      run: docker-compose run --rm manage test users
-      if: always()
+      - name: Test Resources
+        run: docker-compose run --rm manage test resources
+        if: always()
 
-    - name: Test UserAuth
-      run: docker-compose run --rm manage test userauth
-      if: always()
+      - name: Test Users
+        run: docker-compose run --rm manage test users
+        if: always()
+
+      - name: Test UserAuth
+        run: docker-compose run --rm manage test userauth
+        if: always()

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -43,9 +43,9 @@ services:
   # The nginx front-end is configured to proxy all traffic to the Django application.
   # We may want to use this to host static content. It is configured to reload
   # configuration every 6 hours.
-  nginx:
+  web:
     image: nginx:1.17-alpine
-    container_name: nginx
+    container_name: web
     restart: on-failure
     ports:
       - "8000:80"
@@ -89,4 +89,3 @@ services:
       - EMAIL_HOST=mailhog
     depends_on:
       - db
-


### PR DESCRIPTION
 Fixes #68

- Starting unnecessary services takes time and consumes resources
- Remove the need to start optional services; `mailhog` and `adminer`
- Users may need to add the `--remove-orphans` flag the first time they
  run `docker-compose down` after this change. Docker will alert users
  if this is the case.