### PR TITLE
Unblock cors error on react app running on localhost:3000

### DIFF
--- a/project/config/settings/base.py
+++ b/project/config/settings/base.py
@@ -336,6 +336,7 @@ JWT_AUTH = {
 
 CORS_ORIGIN_WHITELIST = (
     'https://127.0.0.1:3000',
+    'http://localhost:3000',
 )
 
 CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
If I have the django and react app running at the same time on localhost:8000 and localhost:3000 respectively, I get a cors error if I try to make requests to localhost:8000/auth/users from the React app:

![image](https://user-images.githubusercontent.com/4512699/76159569-f3eec200-60d6-11ea-9059-bb8ebdbf5cc9.png)

This PR whitelists http://localhost:3000 to prevent the cors error.
