### PR TITLE
serve static assets from nginx

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,7 +30,8 @@ services:
     container_name: app
     restart: on-failure
     command: >
-      sh -c "python /opt/codebuddies/manage.py migrate &&
+      sh -c "python /opt/codebuddies/manage.py collectstatic --clear --no-input &&
+             python /opt/codebuddies/manage.py migrate &&
              uwsgi --ini /opt/codebuddies/uwsgi.ini"
     volumes:
       - ./project:/opt/codebuddies
@@ -51,6 +52,7 @@ services:
       - "8000:80"
     volumes:
       - ./nginx:/etc/nginx/conf.d
+      - ./project/staticfiles/:/static
     command: '/bin/sh -c ''while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g "daemon off;"'''
     depends_on:
       - app

--- a/nginx/app.conf
+++ b/nginx/app.conf
@@ -6,6 +6,10 @@ server {
     listen 80;
     server_name localhost;
 
+    location /static/ {
+        alias /static/;
+    }
+
     location / {
         proxy_pass http://app;
         proxy_set_header Host $http_host;


### PR DESCRIPTION
At the moment, the backend throws a 404 on any javascript or CSS files.
This means the admin interface looks like this:

![Screenshot at 2020-03-10 20-34-33](https://user-images.githubusercontent.com/6025893/76357624-f38d3b80-630f-11ea-857d-c5b86b2d4404.png)

There is clearly intent to use make use of the admin backend e.g: https://github.com/codebuddies/backend/issues/84 . Enabling nginx to serve static assets makes it much more usable:

![Screenshot at 2020-03-10 20-33-58](https://user-images.githubusercontent.com/6025893/76357628-f6882c00-630f-11ea-847e-95bf2e96ea06.png)

..which is nicer :)

In general, this is primarily an API project so the vast majority of production traffic will be serving JSON. Javascript and CSS is only likely to be served to a small handful of admin users so I'd propose this as a production setup. There's not really any point in spending time on a more elaborate solution like farming it out to a static object storage service (S3/Spaces/whatever) to optimise the 1% case.