### PR TITLE
fail the build if migrations are not up-to-date

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,3 +28,7 @@ jobs:
       - name: Test UserAuth
         run: docker-compose run --rm manage test userauth
         if: always()
+
+      - name: Check Migrations are up-to-date
+        run: docker-compose run --rm manage makemigrations --check
+        if: always()


### PR DESCRIPTION
refs #70

This change will cause the build to fail if there changes to a model which have no corresponding migration. Its still important to document it, but this automates the check for it in CI.