### PR TITLE
run pip check in container build

### DIFF
--- a/project/Dockerfile
+++ b/project/Dockerfile
@@ -8,6 +8,7 @@ COPY ./requirements/ /opt/codebuddies/requirements/
 
 RUN python3 -m pip install --upgrade pip
 RUN pip3 install -r /opt/codebuddies/requirements/local.txt
+RUN pip3 check
 
 RUN groupadd -r uwsgi && useradd -r -g uwsgi uwsgi
 


### PR DESCRIPTION
This isn't a solution to #97 but it does improve things, a bit.

Pip can't resolve a consistent dependency tree, but it can detect when its installed conflicting requirements. Calling `pip check` here will cause the container build to fail if that has happened, instead of building a container with invalid/broken dependencies.