### PR TITLE
WIP Coverage reports

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,9 +18,12 @@ jobs:
         run: docker-compose up -d web
 
       - name: Run test suite
-        run: docker-compose run -T --rm app pytest -v --cov-report= --cov=.
-        if: always()
+        run: docker-compose run -T --rm app pytest -v --cov-report=xml --cov=.
 
       - name: Check Migrations are up-to-date
         run: docker-compose run -T --rm app ./manage.py makemigrations --check
-        if: always()
+
+      - name: Upload coverage report to codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./project/coverage.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
         run: docker-compose up -d web
 
       - name: Run test suite
-        run: docker-compose run -T --rm app pytest -v
+        run: docker-compose run -T --rm app pytest -v --cov-report= --cov=.
         if: always()
 
       - name: Check Migrations are up-to-date

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Django proof-of-concept for CodeBuddies V3
 
 ![Test](https://github.com/codebuddies/django-concept/workflows/Test/badge.svg)
+[![codecov](https://codecov.io/gh/codebuddies/backend/branch/master/graph/badge.svg)](https://codecov.io/gh/codebuddies/backend)
+
+
+
 
 Background: https://github.com/codebuddies/codebuddies/issues/1136
 

--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ docker-compose run --rm app ./manage.py help
 * We use [pytest](https://docs.pytest.org/en/latest/contents.html) with the [pytest-django](https://pytest-django.readthedocs.io/en/latest/) plugin for running tests.
 * Please add tests for your code when contributing.
 * Run the test suite using `docker-compose run --rm app pytest`
+* With test coverage report `docker-compose run --rm app pytest --cov-report=term --cov=.`
 
 ### Import Postman collection
 Postman is a free interactive tool for verifying the APIs of your project. You can download it at postman.com/downloads.

--- a/project/.coveragerc
+++ b/project/.coveragerc
@@ -1,5 +1,12 @@
 [run]
-include = project/*
-omit = *migrations*, *tests*
+omit =
+    */apps.py,
+    */config/*,
+    */migrations/*,
+    */tests/*,
+    */tests.py,
+    */*.html,
+    conftest.py,
+    manage.py,
 plugins =
     django_coverage_plugin

--- a/project/requirements/local.txt
+++ b/project/requirements/local.txt
@@ -9,6 +9,7 @@ psycopg2-binary==2.8.3  # https://github.com/psycopg/psycopg2
 # ------------------------------------------------------------------------------
 mypy==0.720  # https://github.com/python/mypy
 pytest==5.1.1  # https://github.com/pytest-dev/pytest
+pytest-cov==2.8.1  # https://github.com/pytest-dev/pytest-cov
 pytest-sugar==0.9.2  # https://github.com/Frozenball/pytest-sugar
 
 # Code quality


### PR DESCRIPTION
Closes #120

This build is probably going to fail too when it tries to submit the coverage report.

I've set up this repo on coveralls at https://coveralls.io/github/codebuddies/backend

This missing piece of the jigsaw on this one is I we need to set `COVERALLS_REPO_TOKEN` in the repo secrets so that we can POST the coverage report, but I don't have access to do this. 

Can someone with access to modify the repo secrets:

* Go to https://coveralls.io/ and "sign in with github"
* Go to https://coveralls.io/github/codebuddies/backend when you're signed in.
* Copy the repo token
* Go to https://github.com/codebuddies/backend/settings/secrets and add a secret with the name `COVERALLS_REPO_TOKEN` and the value as the token we copied

Then let me know. I'll confirm this works and we can wrap this one up.

Alternatively, if you'd rather use a different coverage service, let me know and we can revisit it..


Edit: gah - meant to create this as a _draft_ PR :roll_eyes: 