### PR TITLE
use MD5 password hasher under test

### DIFF
--- a/project/config/settings/test.py
+++ b/project/config/settings/test.py
@@ -25,6 +25,11 @@ CACHES = {
     }
 }
 
+# PASSWORDS
+# ------------------------------------------------------------------------------
+# https://docs.djangoproject.com/en/dev/ref/settings/#password-hashers
+PASSWORD_HASHERS = ["django.contrib.auth.hashers.MD5PasswordHasher"]
+
 # TEMPLATES
 # ------------------------------------------------------------------------------
 TEMPLATES[0]["OPTIONS"]["loaders"] = [  # noqa F405


### PR DESCRIPTION
This restores the optimisation I removed in https://github.com/codebuddies/backend/pull/109 to get the tests working.
Now that we're using Factories rather than fixtures, we can use what we want under test.

A good production password hashing algorithm is slow by design and hard to optimise. This makes it difficult to brute-force. The reason cookiecutter suggests this is because MD5 is not very secure but it is fast to calculate. We don't care about security of data we generate while running tests, but we do want it to be fast to build, so using a known vulnerable hash algorithm makes sense here. Its a bit of a micro-optimisation, but its definitely not going to make the tests run any slower, so we might as well re-enable it now.