### PR TITLE
fix: Docker pip install - create directory for `/requirements/`

### DIFF
--- a/project/Dockerfile
+++ b/project/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get install -y && \
     pip3 install uwsgi
 
+RUN mkdir -p /opt/codebuddies/requirements/
 COPY ./requirements/ /opt/codebuddies/requirements/
 
 RUN python3 -m pip install --upgrade pip


### PR DESCRIPTION
error message: copy failed stat .../requirements: no such file or directory
error line: https://github.com/codebuddies/backend/blob/675ef04f70930f9951b2638a22cd1aa7a1a460c3/project/Dockerfile#L7
slack thread: https://codebuddies.slack.com/archives/C04BRN86J/p1587889877253000