### PR TITLE
[Issue 125 Fix] :  Added Serializer Field to Properly Resolve Choices in Resource.media_type Field

### DIFF
--- a/project/resources/serializers.py
+++ b/project/resources/serializers.py
@@ -7,7 +7,20 @@ from tagging.serializers import TagSerializer, TagsSerializerField
 class MediaTypeSerializerField(serializers.ChoiceField):
 
     def to_representation(self, value):
-            return "" if not value else self.choices[value]
+
+        valid_media_types = ', '.join(item for item in self.choices)
+
+        if not value:
+            return ''
+
+        else:
+            try:
+                media_type = self.choices[value]
+
+            except KeyError as err:
+                raise KeyError(f'Invalid media type.  The media type should be one of the following: {valid_media_types}') from err
+
+            return media_type
 
     def to_internal_value(self,  value):
         return value

--- a/project/resources/serializers.py
+++ b/project/resources/serializers.py
@@ -4,11 +4,19 @@ from userauth.serializers import UserSerializer
 from tagging.serializers import TagSerializer, TagsSerializerField
 
 
+class MediaTypeSerializerField(serializers.ChoiceField):
+
+    def to_representation(self, value):
+            return "" if not value else self.choices[value]
+
+    def to_internal_value(self,  value):
+        return value
+
 
 class ResourceSerializer(TagSerializer, serializers.ModelSerializer):
 
     tags = TagsSerializerField(model_field='tags', default='')
-    media_type = serializers.SerializerMethodField()
+    media_type = MediaTypeSerializerField(choices=Resource.RESOURCE_TYPES, allow_blank=True)
     user = UserSerializer(read_only=True)
 
     class Meta:
@@ -31,8 +39,3 @@ class ResourceSerializer(TagSerializer, serializers.ModelSerializer):
             'paid',
             'tags'
         )
-
-
-    def get_media_type(self, obj):
-        return obj.get_media_type_display()
-

--- a/project/resources/tests.py
+++ b/project/resources/tests.py
@@ -1,4 +1,5 @@
 from unittest import skip
+from pytest import raises
 from random import randint
 from rest_framework import status
 from rest_framework.test import APITestCase
@@ -186,3 +187,22 @@ class AuthedResourcesTests(APITestCase):
         self.assertEqual(response.data['title'], "The Best Medium-Hard Data Analyst SQL Interview Questions")
         self.assertEqual(response.data['other_referring_source'], "twitter.com/lpnotes")
         self.assertEqual(response.data['media_type'], '')
+
+    def test_create_one_resource_with_invalid_media_type(self):
+        with raises(KeyError, match=r"The media type should be one of the following:"):
+            url = '/api/v1/resources/'
+            data = {"title": "The Best Medium-Hard Data Analyst SQL Interview Questions",
+                    "author": "Zachary Thomas",
+                    "description": "The first 70% of SQL is pretty straightforward but the remaining 30% can be pretty tricky.  These are good practice problems for that tricky 30% part.",
+                    "url": "https://quip.com/2gwZArKuWk7W",
+                    "referring_url": "https://quip.com",
+                    "other_referring_source": "twitter.com/lpnotes",
+                    "date_published": "2020-04-19T03:27:06Z",
+                    "created": "2020-05-02T03:27:06.485Z",
+                    "modified":  "2020-05-02T03:27:06.485Z",
+                    "media_type": "DOP",
+                    "tags": ["SQLt", "BackEnd", "Databases"]
+                    }
+
+            response = self.client.post(url, data, format='json')
+

--- a/project/resources/tests.py
+++ b/project/resources/tests.py
@@ -145,8 +145,7 @@ class AuthedResourcesTests(APITestCase):
         self.assertEqual(response.data['title'], new_resource.title)
         self.assertEqual(response.data['description'], new_resource.description)
 
-    @skip('https://github.com/codebuddies/backend/issues/125')
-    def test_create_one_resource(self):
+    def test_create_one_resource_with_media_type(self):
         url = '/api/v1/resources/'
         data = {"title": "The Modern JavaScript Tutorial",
                 "author": "iliakan",
@@ -165,4 +164,25 @@ class AuthedResourcesTests(APITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data['title'], "The Modern JavaScript Tutorial")
         self.assertEqual(response.data['other_referring_source'], "iliakan@javascript.info")
-        self.assertEqual(response.data['media_type'], 'WEB')
+        self.assertEqual(response.data['media_type'], 'Website')
+
+    def test_create_one_resource_without_media_type(self):
+        url = '/api/v1/resources/'
+        data = {"title": "The Best Medium-Hard Data Analyst SQL Interview Questions",
+                "author": "Zachary Thomas",
+                "description": "The first 70% of SQL is pretty straightforward but the remaining 30% can be pretty tricky.  These are good practice problems for that tricky 30% part.",
+                "url": "https://quip.com/2gwZArKuWk7W",
+                "referring_url": "https://quip.com",
+                "other_referring_source": "twitter.com/lpnotes",
+                "date_published": "2020-04-19T03:27:06Z",
+                "created": "2020-05-02T03:27:06.485Z",
+                "modified":  "2020-05-02T03:27:06.485Z",
+                "media_type": "",
+                "tags": ["SQLt", "BackEnd", "Databases"]
+                }
+
+        response = self.client.post(url, data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data['title'], "The Best Medium-Hard Data Analyst SQL Interview Questions")
+        self.assertEqual(response.data['other_referring_source'], "twitter.com/lpnotes")
+        self.assertEqual(response.data['media_type'], '')


### PR DESCRIPTION
Should fix #125.

*  Added `class MediaTypeSerializerField(serializers.ChoiceField)` with a `to_representation` and a `to_internal_value` to properly resolve the `choices` on the `Resource.media_type` field for Resources. in **`resources/serializers.py`**

*  Corrected and un-commented the `create_one_resource_with_media_type` test case and added a new `create_one_resource_without_media_type` test case for coverage. in **`resources/tests.py`**