### PR TITLE
Add stale.yml file

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,18 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 30
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - wontfix
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false


### PR DESCRIPTION
### Background/Context
Adds a stale bot that will comb through issues and close them after inactivity. 

### Before and After
Before: all issues stayed around forever
After: cleanup

### Acknowledgments (optional)
@BethanyG for suggesting https://github.com/marketplace/stale

### Other notes (optional)
Made a distinction between `wontfix` labels (issues we want to keep open) and `stale` (issues that should get archived)
