### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: "[Bug] "
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+open_a_discussion:
+  - name: Open a discussion
+    url: https://github.com/codebuddies/backend/discussions/new
+    about: Open a new discussion

--- a/.github/ISSUE_TEMPLATE/custom.md
+++ b/.github/ISSUE_TEMPLATE/custom.md
@@ -1,0 +1,10 @@
+---
+name: Custom issue template
+about: Describe this issue template's purpose here.
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,14 @@
+---
+name: Documentation
+about: Create a ticket to add or update documentation.
+title: "[Documentation] "
+labels: ''
+assignees: ''
+
+---
+
+## Context
+
+## Acceptance Criteria
+- [ ] 
+- [ ]

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: "[Feature] "
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,14 @@
+---
+name: Other
+about: Create a ticket that doesn't fall in any other category
+title: "[Other] "
+labels: ''
+assignees: ''
+
+---
+
+## Context
+
+## Acceptance Criteria
+- [ ] 
+- [ ]

--- a/.github/ISSUE_TEMPLATE/refactor.md
+++ b/.github/ISSUE_TEMPLATE/refactor.md
@@ -1,0 +1,14 @@
+---
+name: Refactor
+about: Create a ticket to refactor some code.
+title: "[Refactor] "
+labels: ''
+assignees: ''
+
+---
+
+## Context
+
+## Acceptance Criteria
+- [ ] 
+- [ ]

--- a/.github/ISSUE_TEMPLATE/tests-needed.md
+++ b/.github/ISSUE_TEMPLATE/tests-needed.md
@@ -1,0 +1,14 @@
+---
+name: Tests Needed
+about: Create a ticket to add or update tests
+title: "[Tests] "
+labels: ''
+assignees: ''
+
+---
+
+## Context
+
+## Acceptance Criteria
+- [ ] 
+- [ ]

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,5 +1,5 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+daysUntilStale: 60
 # Number of days of inactivity before a stale issue is closed
 daysUntilClose: 7
 # Issues with these labels will never be considered stale


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] 🐛 Bug Fix
- [ ] ✨ Feature (_**e.g.** API change, enhancement, addition, etc._)
- [ ] ♻️ Refactor
- [x] 📝 Documentation
- [ ] 🔖 Release
- [ ] 🚩 Other (**concerning:**  issue templates        )

## Context

- [x] Closes https://github.com/codebuddies/backend/issues/119 by setting up issue templates with the following categories: 
Bug
Feature
Refactor
Documentation
Tests Needed
Start a Discussion
Other

- [x] Updated stalebot to be 60 instead of 30 days

## Other Related Tickets & Documents (as needed)


## Implementation Details

Followed the docs at https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository. I'm *hoping* that the "Start a Discussion" template in config.yml works as expected!

## New Libraries/Dependancies Introduced (Fill out as needed)


If you have added libraries or other dependancies, please list them (and links to their repos) below:


## Any new migration files added?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed

## Did you add tests?
**_Code added or changed without test coverage or good reason for exemption won't be approved._**

- [ ] 👍 yes
- [ ] 🙋 no, because I need help
- [x] 🙅 no, because they aren't needed

